### PR TITLE
TOOLS-2582 Slack channels need renaming or not specifying in Jenkinsfiles, post-EdgeCast-move.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2021 Joyent, Inc.
+ * Copyright 2025 MNX Cloud, Inc.
  */
 
 @Library('jenkins-joylib@v1.0.8') _
@@ -58,7 +59,7 @@ make print-BRANCH print-STAMP all release publish buildimage bits-upload;
 
     post {
         always {
-            joySlackNotifications(channel: 'jenkins')
+            joySlackNotifications()
         }
     }
 


### PR DESCRIPTION
Now granted this repo is no longer used, and probably should be yanked from the list of Triton repos, but moving this one along just on the off-chance...  IT WILL NOT BUILD so that will X out on the PR.